### PR TITLE
Fix sqlite version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.6.1'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.2', '>= 5.2.2.1'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.3.6'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.0)
+    sqlite3 (1.3.13)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -207,7 +207,7 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
+  sqlite3 (~> 1.3.6)
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)


### PR DESCRIPTION
## Purpose
* Sqlite3がrails5.2.2と相性が悪く、立ち上げた際にエラーが出るので、それの解消。

## References
https://github.com/rails/rails/pull/35154 
https://github.com/rails/rails/issues/35387 

## Info
Railsのリポジトリでmasterにはマージされているようですが、5.2.2.1のセキュリティパッチのアップデートには含まれなかったらしいので、もしかしたら次の5系のマイナーアップデート版がリリースされたらnewするときにエラー出ないかも。